### PR TITLE
The do_create method refers to a command line argument that doesn't exist

### DIFF
--- a/hostedpi/cli.py
+++ b/hostedpi/cli.py
@@ -370,7 +370,7 @@ class CLI:
         model = self._args.model
         disk_size = self._args.disk
         ssh_key_path = self._args.ssh_key_path
-        os_image = self._args.os_image
+        os_image = self._args.image
         args = {
             'model': model,
             'disk_size': disk_size,


### PR DESCRIPTION
Hi - tried this after your talk on Raspberry pint and it fails on create as it is looking for a CLI parameter called os_image and not image. 

The error as follows:

```
$ hostedpi create mypi --model 3 --image stretch
Traceback (most recent call last):
  File "/Users/gnuchu/projects/pipipipipi/.venv/bin/hostedpi", line 8, in <module>
    sys.exit(main())
  File "/Users/gnuchu/projects/pipipipipi/.venv/lib/python3.9/site-packages/hostedpi/cli.py", line 25, in __call__
    return self._args.func()
  File "/Users/gnuchu/projects/pipipipipi/.venv/lib/python3.9/site-packages/hostedpi/cli.py", line 373, in do_create
    os_image = self._args.os_image
AttributeError: 'Namespace' object has no attribute 'os_image'
```

edit:
Thought this might be something to do with running on a mac rather than a pi but have now replacated on a pi:
```
$  python3 -m venv .venv
$  source .venv/bin/activate
$  pip install hostedpi
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting hostedpi
  Downloading https://files.pythonhosted.org/packages/96/a7/3c7745dd2d99b4cdf9273ca153b4d7041cfed7f5f959e5ef7783e8739c75/hostedpi-0.1.0-py3-none-any.whl
Collecting requests (from hostedpi)
  Downloading https://files.pythonhosted.org/packages/29/c1/24814557f1d22c56d50280771a17307e6bf87b70727d975fd6b2ce6b014a/requests-2.25.1-py2.py3-none-any.whl (61kB)
    100% |████████████████████████████████| 61kB 1.9MB/s
Requirement already satisfied: setuptools in ./.venv/lib/python3.7/site-packages (from hostedpi) (40.8.0)
Collecting chardet<5,>=3.0.2 (from requests->hostedpi)
  Downloading https://files.pythonhosted.org/packages/19/c7/fa589626997dd07bd87d9269342ccb74b1720384a4d739a1872bd84fbe68/chardet-4.0.0-py2.py3-none-any.whl (178kB)
    100% |████████████████████████████████| 184kB 2.3MB/s
Collecting idna<3,>=2.5 (from requests->hostedpi)
  Downloading https://files.pythonhosted.org/packages/a2/38/928ddce2273eaa564f6f50de919327bf3a00f091b5baba8dfa9460f3a8a8/idna-2.10-py2.py3-none-any.whl (58kB)
    100% |████████████████████████████████| 61kB 4.1MB/s
Collecting certifi>=2017.4.17 (from requests->hostedpi)
  Downloading https://files.pythonhosted.org/packages/5e/a0/5f06e1e1d463903cf0c0eebeb751791119ed7a4b3737fdc9a77f1cdfb51f/certifi-2020.12.5-py2.py3-none-any.whl (147kB)
    100% |████████████████████████████████| 153kB 3.1MB/s
Collecting urllib3<1.27,>=1.21.1 (from requests->hostedpi)
  Downloading https://files.pythonhosted.org/packages/09/c6/d3e3abe5b4f4f16cf0dfc9240ab7ce10c2baa0e268989a4e3ec19e90c84e/urllib3-1.26.4-py2.py3-none-any.whl (153kB)
    100% |████████████████████████████████| 153kB 2.8MB/s
Installing collected packages: chardet, idna, certifi, urllib3, requests, hostedpi
Successfully installed certifi-2020.12.5 chardet-4.0.0 hostedpi-0.1.0 idna-2.10 requests-2.25.1 urllib3-1.26.4
$ export HOSTEDPI_ID=xxxxxxx
$ export HOSTEDPI_SECRET=xxxxxxx
$ hostedpi test
Connected to the Mythic Beasts API
$ hostedpi create pipipi
Traceback (most recent call last):
  File "/home/pi/.venv/bin/hostedpi", line 10, in <module>
    sys.exit(main())
  File "/home/pi/.venv/lib/python3.7/site-packages/hostedpi/cli.py", line 25, in __call__
    return self._args.func()
  File "/home/pi/.venv/lib/python3.7/site-packages/hostedpi/cli.py", line 373, in do_create
    os_image = self._args.os_image
AttributeError: 'Namespace' object has no attribute 'os_image'
```